### PR TITLE
feat: 감정 카드 CRUD 및 AI 제안 기능 강화

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,11 +1,13 @@
 import axios from 'axios';
 
 const instance = axios.create({
-  baseURL: 'https://reconnect-backend.onrender.com', // 항상 배포된 백엔드 사용
+  baseURL: 'https://reconnect-backend.onrender.com/api', // baseURL에 '/api' 추가
   withCredentials: true,
   headers: {
     'Content-Type': 'application/json',
   },
 });
+
+console.log('[axiosInstance] baseURL:', instance.defaults.baseURL); // baseURL 확인 로그 추가
 
 export default instance; 

--- a/src/components/common/SubmitButton.tsx
+++ b/src/components/common/SubmitButton.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import styled, { css } from 'styled-components';
+
+interface SubmitButtonProps {
+  onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void; // onClick 타입 명시
+  children: React.ReactNode;
+  disabled?: boolean;
+  type?: 'button' | 'submit' | 'reset'; // 버튼 타입 추가
+  className?: string; // 외부에서 스타일 확장을 위해 className prop 추가
+  size?: 'small' | 'medium' | 'large'; // size prop 추가
+  width?: string; // width prop 추가
+}
+
+// size prop에 따른 스타일 정의
+const sizeStyles = {
+  small: css`
+    padding: 0.5rem 0.8rem;
+    font-size: 0.875rem;
+  `,
+  medium: css`
+    padding: 1rem;
+    font-size: 1rem;
+  `,
+  large: css`
+    padding: 1.2rem 1.5rem;
+    font-size: 1.125rem;
+  `,
+};
+
+// SubmitButtonStyled에서 실제 사용하는 props만 Pick으로 지정
+const SubmitButtonStyled = styled.button<Pick<SubmitButtonProps, 'size' | 'disabled' | 'width'>>`
+  font-weight: 500;
+  background: linear-gradient(to right, #FF69B4, #4169E1);
+  color: white;
+  border: none; // BaseButton의 border: none;
+  border-radius: 30px;
+  cursor: pointer;
+  transition: transform 0.2s;
+  ${({ width }) => width ? `width: ${width};` : 'width: 100%; max-width: 340px;'} // width prop에 따른 조건부 스타일
+
+  ${({ size = 'medium' }) => sizeStyles[size]} // size prop에 따른 스타일 적용
+
+  &:hover:not(:disabled) {
+    transform: translateY(-2px);
+  }
+
+  ${({ disabled }) => 
+    disabled && 
+    css`
+      background: #cbd5e1;
+      color: #94a3b8;
+      cursor: not-allowed;
+      transform: none;
+  `}
+`;
+
+const SubmitButton: React.FC<SubmitButtonProps> = ({ 
+  onClick,
+  children,
+  disabled = false,
+  type = 'button',
+  className,
+  size = 'medium', // size prop 기본값 설정
+  width // width prop 추가
+}) => {
+  return (
+    <SubmitButtonStyled 
+      onClick={onClick} 
+      disabled={disabled} 
+      type={type}
+      className={className}
+      size={size} // size prop 전달
+      width={width} // width prop 전달
+    >
+      {children}
+    </SubmitButtonStyled>
+  );
+};
+
+export default SubmitButton; 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,7 @@
+import { 쓰는곳 } from "./store"; 
+
+const API_URL = "https://reconnect-backend.onrender.com/api"; // 배포된 백엔드 주소로 변경
+
+export const logout = async () => {
+// ... (나머지 logout 함수 코드는 동일) ...
+} 

--- a/src/pages/EmotionCard.tsx
+++ b/src/pages/EmotionCard.tsx
@@ -1,87 +1,287 @@
-// src/pages/EmotionCard.tsx (업데이트된 부분)
-import React, { useState } from "react";
+// src/pages/EmotionCard.tsx (백엔드 연동 수정)
+import React, { useState, useEffect } from "react";
 import styled from "styled-components";
-import NavigationBar from "../components/NavigationBar"; // NavigationBar 임포트
+import NavigationBar from "../components/NavigationBar";
+import BackButton from "../components/common/BackButton";
+import SubmitButton from "../components/common/SubmitButton";
 
-const Container = styled.div`
+// 아이콘 (SVG 등 사용 가능, 여기서는 텍스트로 대체)
+const SparkleIcon = () => <span style={{ marginRight: "0.5rem" }}>✨</span>;
+
+// SentMessage 타입 정의 (백엔드 응답 기준)
+interface SentMessage {
+  id: string; // 서버에서 생성된 ID (문자열로 가정)
+  text: string;
+  createdAt: string; // 서버에서 내려오는 타임스탬프 (ISO 문자열로 가정)
+  // 필요하다면 userId 등 추가 필드 정의 가능
+}
+
+const PageContainer = styled.div`
+  min-height: 100vh;
+  background-color: #f0f4f8; // 부드러운 배경색
   padding: 2rem;
-  min-height: calc(100vh - 60px); /* NavigationBar 높이만큼 줄임 */
-  background-color: #ecfeff;
-  padding-bottom: 80px; /* NavigationBar에 가려지지 않도록 하단 패딩 추가 */
+  padding-bottom: 8rem; // 하단 패딩 추가 (네비게이션 바 고려, 기존 2rem + 추가 6rem)
+  display: flex;
+  flex-direction: column;
+  align-items: center; // 자식 요소들을 가로축 중앙 정렬 (PageHeaderContainer, ContentWrapper)
+  // justify-content: center; // 전체 페이지 세로 중앙 정렬은 일단 보류 (타이틀/백버튼 묶음을 상단에 가깝게)
 `;
 
-const Title = styled.h2`
-  font-size: 1.5rem;
-  margin-bottom: 1rem;
-  color: #0369a1;
+// 뒤로가기 버튼과 페이지 타이틀을 묶는 컨테이너
+const PageHeaderContainer = styled.div`
+  display: flex;
+  align-items: center; // BackButton과 PageTitle을 세로 중앙 정렬
+  justify-content: center; // 내부 요소들을 가로 중앙에 배치 (타이틀 기준)
+  width: 100%; // PageContainer의 align-items:center에 의해 중앙 정렬되도록 너비 확보
+  max-width: 600px; // ContentWrapper와 동일한 최대 너비로 일관성 유지
+  margin-bottom: 1.5rem; // ContentWrapper와의 간격
+  position: relative; // BackButton을 왼쪽에 배치하기 위한 기준점
+`;
+
+const StyledBackButton = styled(BackButton)`
+  position: absolute; // PageHeaderContainer를 기준으로 절대 위치
+  left: 0; // 왼쪽에 배치
+  top: 50%; // 세로 중앙 정렬 시도
+  transform: translateY(-50%); // 세로 중앙 정렬 시도
+`;
+
+const PageTitle = styled.h2`
+  font-size: 1.75rem; // 기본 글씨 크기
+  font-weight: 600;
+  color: #2d3748;
+  text-align: center;
+  // margin-bottom 제거 (PageHeaderContainer에서 관리)
+  // PageHeaderContainer의 justify-content:center로 인해 중앙 정렬됨
+
+  @media (max-width: 768px) { // 모바일 화면 크기 (예: 768px 이하)
+    font-size: 1.2rem; // 모바일에서 글씨 크기 조정
+  }
+`;
+
+const ContentWrapper = styled.div`
+  background-color: #ffffff;
+  padding: 2rem;
+  border-radius: 1rem;
+  box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+  width: 100%;
+  max-width: 600px;
+  margin-top: 1rem; // PageHeaderContainer와의 추가 간격 (선택 사항)
 `;
 
 const TextArea = styled.textarea`
   width: 100%;
-  min-height: 120px;
-  border-radius: 1rem;
+  min-height: 150px; // 높이 증가
+  border-radius: 0.75rem;
   padding: 1rem;
-  border: 1px solid #cbd5e1;
-  margin-bottom: 1rem;
+  border: 1px solid #e2e8f0;
+  margin-bottom: 1.5rem;
   font-size: 1rem;
+  color: #4a5568;
+  resize: vertical; // 세로 크기만 조절 가능
+
+  &:focus {
+    outline: none;
+    border-color: #3b82f6; // 프로젝트 주요 색상 (예시: blue-500)
+    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.3);
+  }
 `;
 
-const SuggestionBox = styled.div`
-  background-color: #e0f2fe;
-  border-left: 4px solid #0284c7;
-  padding: 1rem;
+const SuggestionContainer = styled.div`
+  background-color: #f0f9ff; // 연한 하늘색 배경 (예시: sky-50)
+  border: 1px solid #bae6fd; // 연한 하늘색 테두리 (예시: sky-200)
+  padding: 1.5rem;
   border-radius: 0.75rem;
+  margin-bottom: 1.5rem;
+  color: #0c4a6e; // 어두운 하늘색 텍스트 (예시: sky-800)
+`;
+
+const SuggestionHeader = styled.p`
+  font-weight: 500;
+  margin-bottom: 0.75rem;
+  display: flex;
+  align-items: center;
+`;
+
+const SuggestionText = styled.p`
+  line-height: 1.6;
   margin-bottom: 1rem;
-  color: #075985;
-  font-size: 0.95rem;
 `;
 
 const ErrorMessage = styled.p`
   color: #ef4444; // Tailwind red-500
   font-size: 0.9rem;
-  margin-bottom: 1rem;
+  margin-bottom: 1.5rem;
+  text-align: center;
 `;
 
 const ButtonGroup = styled.div`
   display: flex;
-  flex-wrap: wrap; // 버튼이 많아질 경우 줄바꿈 허용
   gap: 1rem;
-  justify-content: flex-end;
+  justify-content: flex-end; // 버튼 그룹을 오른쪽으로 정렬
+  align-items: center;
+  flex-wrap: wrap; // 너비가 부족할 경우 줄바꿈 (필요시)
 `;
 
-const Button = styled.button`
-  background-color: #0284c7;
-  color: white;
-  padding: 0.75rem 1.5rem;
+const TextButton = styled.button`
+  padding: 0.5rem 1rem;
   border: none;
-  border-radius: 0.75rem;
+  border-radius: 0.5rem;
   cursor: pointer;
   font-weight: 500;
+  font-size: 0.95rem;
+  background-color: transparent;
+  color: #3b82f6; // blue-500
+  transition: background-color 0.2s ease-in-out;
+
   &:hover:not(:disabled) {
-    background-color: #0369a1;
+    background-color: rgba(59, 130, 246, 0.1); // 연한 파란색 배경
   }
+
   &:disabled {
-    background-color: #94a3b8; // Tailwind slate-400
+    background-color: transparent;
+    color: #94a3b8; // Tailwind slate-400
     cursor: not-allowed;
   }
 `;
 
-// 임시 더미 제안 목록
-const dummySuggestions = [
-  "오늘 정말 멋진 하루였어! 네 덕분에 힘이 나.",
-  "괜찮아, 누구나 그럴 수 있어. 너무 자책하지 마.",
-  "네 마음이 조금이나마 편해졌으면 좋겠다.",
-  "힘든 일이 있었구나. 내가 옆에 있어줄게.",
-  "네 생각을 말해줘서 고마워. 더 이해할 수 있게 됐어.",
-];
+// 카드 목록 및 모달을 위한 스타일 추가
+const SentCardsSection = styled.section`
+  width: 100%;
+  max-width: 600px;
+  margin-top: 2rem;
+`;
 
-let suggestionIndex = 0;
+const SentCardsTitle = styled.h3`
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #2d3748;
+  margin-bottom: 1rem;
+`;
+
+const SentCardList = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); // 반응형 그리드
+  gap: 1rem;
+`;
+
+const SentCardItem = styled.div`
+  background-color: #ffffff;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  cursor: pointer;
+  transition: transform 0.2s ease-in-out;
+
+  &:hover {
+    transform: translateY(-2px);
+  }
+
+  p {
+    font-size: 0.875rem;
+    color: #4a5568;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    margin-bottom: 0.5rem;
+  }
+
+  span {
+    font-size: 0.75rem;
+    color: #718096;
+  }
+`;
+
+const ModalBackground = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000; // NavigationBar보다 위에 오도록
+`;
+
+const ModalContent = styled.div`
+  background-color: #ffffff;
+  padding: 2rem;
+  border-radius: 0.75rem;
+  width: 90%;
+  max-width: 500px;
+  box-shadow: 0 10px 25px -5px rgba(0,0,0,0.1), 0 10px 10px -5px rgba(0,0,0,0.04);
+  position: relative;
+
+  h4 {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin-bottom: 1rem;
+  }
+
+  p {
+    font-size: 1rem;
+    line-height: 1.6;
+    margin-bottom: 1.5rem;
+    white-space: pre-wrap; // 줄바꿈 유지
+  }
+`;
+
+const CloseButton = styled.button`
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  background: transparent;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+  color: #4a5568;
+
+  &:hover {
+    color: #1a202c;
+  }
+`;
+
+// API Base URL (환경 변수 등에서 관리하는 것이 좋음)
+const API_BASE_URL = "https://reconnect-backend.onrender.com/api"; 
 
 const EmotionCard: React.FC = () => {
   const [message, setMessage] = useState("");
   const [suggestion, setSuggestion] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(false); // AI 제안 로딩
+  const [isSubmitting, setIsSubmitting] = useState(false); // 카드 전송 로딩
   const [error, setError] = useState<string | null>(null);
+  
+  const [sentMessages, setSentMessages] = useState<SentMessage[]>([]);
+  const [isLoadingCards, setIsLoadingCards] = useState(false); // 카드 목록 로딩
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [selectedMessage, setSelectedMessage] = useState<SentMessage | null>(null);
+
+  // 카드 목록 불러오기
+  useEffect(() => {
+    const fetchSentMessages = async () => {
+      setIsLoadingCards(true);
+      setError(null);
+      try {
+        // 실제로는 인증 토큰 등을 헤더에 포함해야 함
+        const response = await fetch(`${API_BASE_URL}/emotion-cards`); 
+        if (!response.ok) {
+          throw new Error('감정 카드 목록을 불러오는데 실패했습니다.');
+        }
+        const data: SentMessage[] = await response.json();
+        setSentMessages(data.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())); // 최신순 정렬
+      } catch (err) {
+        if (err instanceof Error) {
+          setError(err.message);
+        } else {
+          setError("알 수 없는 오류로 카드 목록을 불러오지 못했습니다.");
+        }
+      } finally {
+        setIsLoadingCards(false);
+      }
+    };
+    fetchSentMessages();
+  }, []);
 
   const handleSuggest = async () => {
     if (message.trim().length === 0) {
@@ -89,94 +289,163 @@ const EmotionCard: React.FC = () => {
       setSuggestion(null);
       return;
     }
-    setIsLoading(true);
+    setIsLoading(true); // AI 제안 로딩 시작
     setError(null);
-    setSuggestion(null); // 이전 제안 숨기기
-
-    // 실제 API 호출 대신 임시 목업 로직
+    setSuggestion(null);
     try {
-      //   const response = await fetch('/api/emotion-cards/refine-text', {
-      //     method: 'POST',
-      //     headers: { 'Content-Type': 'application/json' },
-      //     body: JSON.stringify({ text: message }),
-      //   });
-      //   if (!response.ok) {
-      //     const errorData = await response.json();
-      //     throw new Error(errorData.message || 'AI 제안을 가져오는데 실패했습니다.');
-      //   }
-      //   const data = await response.json();
-      //   setSuggestion(data.refinedText);
-
-      // 임시 더미 제안 (여러 번 제안 기능 흉내)
-      await new Promise(resolve => setTimeout(resolve, 1000)); // 1초 딜레이
-      setSuggestion(dummySuggestions[suggestionIndex]);
-      suggestionIndex = (suggestionIndex + 1) % dummySuggestions.length;
-
-    } catch (err) {
-      if (err instanceof Error) {
-        setError(err.message);
-      } else {
-        setError("알 수 없는 오류가 발생했습니다.");
+      const response = await fetch(`${API_BASE_URL}/emotion-cards/refine-text`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: message }),
+      });
+      if (!response.ok) {
+        let errorMessageText = 'AI 제안을 가져오는데 실패했습니다.';
+        try { const errorData = await response.json(); errorMessageText = errorData.message || errorMessageText; } catch (e) {}
+        throw new Error(errorMessageText);
       }
+      const data = await response.json();
+      setSuggestion(data.refinedText);
+    } catch (err) {
+      if (err instanceof Error) { setError(err.message); } else { setError("AI 제안 중 알 수 없는 오류 발생"); }
       setSuggestion(null);
     } finally {
-      setIsLoading(false);
+      setIsLoading(false); // AI 제안 로딩 종료
     }
   };
 
   const applySuggestion = () => {
-    if (suggestion) {
-      setMessage(suggestion);
-      // setSuggestion(null); // 제안 적용 후 제안 박스 숨기거나 유지 (선택)
+    if (suggestion) setMessage(suggestion);
+  };
+
+  const handleSubmit = async () => {
+    if (message.trim().length === 0) {
+      setError("보낼 메시지를 입력해주세요.");
+      return;
+    }
+    setIsSubmitting(true); // 전송 로딩 시작
+    setError(null);
+    try {
+      // 실제로는 인증 토큰 등을 헤더에 포함해야 함
+      const response = await fetch(`${API_BASE_URL}/emotion-cards`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: message }),
+      });
+      if (!response.ok) {
+        let errorData;
+        try { errorData = await response.json(); } catch(e){}
+        throw new Error(errorData?.message || '감정 카드 전송에 실패했습니다.');
+      }
+      const newCard: SentMessage = await response.json();
+      setSentMessages(prevMessages => [newCard, ...prevMessages].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()));
+      setMessage("");
+      setSuggestion(null);
+    } catch (err) {
+      if (err instanceof Error) { setError(err.message); } else { setError("카드 전송 중 알 수 없는 오류 발생"); }
+    } finally {
+      setIsSubmitting(false); // 전송 로딩 종료
     }
   };
 
-  const handleSubmit = () => {
-    // 실제 전송 로직은 여기에 구현
-    alert(`감정카드 전송 완료\n내용: ${message}`);
-    // 전송 후 상태 초기화 (선택 사항)
-    // setMessage("");
-    // setSuggestion(null);
-    // setError(null);
+  const openModal = (msg: SentMessage) => {
+    setSelectedMessage(msg);
+    setIsModalOpen(true);
+  };
+
+  const closeModal = () => {
+    setIsModalOpen(false);
+    setSelectedMessage(null);
   };
 
   return (
-    <> {/* Fragment로 감싸서 NavigationBar와 함께 렌더링 */}
-      <Container>
-        <Title>오늘의 감정카드 작성</Title>
-        <TextArea
-          value={message}
-          onChange={(e) => setMessage(e.target.value)}
-          placeholder="오늘 느낀 감정을 짧게 표현해보세요."
-          disabled={isLoading}
-        />
+    <>
+      <PageContainer>
+        <PageHeaderContainer>
+          <StyledBackButton /> {/* 스타일링된 BackButton 사용 */}
+          <PageTitle>오늘의 감정카드 작성</PageTitle>
+        </PageHeaderContainer>
+        
+        <ContentWrapper>
+          <TextArea
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            placeholder="오늘 느낀 감정을 파트너에게 전달해보세요. AI가 따뜻한 말로 다듬어 줄 거예요. 가능한 상황에 대해 자세히 써주시면 AI가 상황을 판단하고 더 자연스럽게 바꿔줄거에요."
+            disabled={isLoading || isSubmitting}
+          />
 
-        {error && <ErrorMessage>{error}</ErrorMessage>}
+          {error && <ErrorMessage>{error}</ErrorMessage>}
 
-        {suggestion && (
-          <SuggestionBox>
-            <p style={{ marginBottom: '0.5rem' }}>✨ AI 제안:</p>
-            <p>{suggestion}</p>
-            <Button
-              onClick={applySuggestion}
-              style={{ marginTop: '1rem', backgroundColor: '#0ea5e9' }} // Tailwind sky-500
-              disabled={isLoading}
+          {suggestion && (
+            <SuggestionContainer>
+              <SuggestionHeader>
+                <SparkleIcon /> AI 추천 메시지
+              </SuggestionHeader>
+              <SuggestionText>{suggestion}</SuggestionText>
+              <TextButton
+                onClick={applySuggestion}
+                disabled={isLoading || isSubmitting}
+                style={{ alignSelf: "flex-start" }} // 왼쪽 정렬
+              >
+                이 내용 사용하기
+              </TextButton>
+            </SuggestionContainer>
+          )}
+
+          <ButtonGroup>
+            <SubmitButton 
+              onClick={handleSuggest} 
+              disabled={isLoading || isSubmitting || message.trim().length === 0}
+              size="small"
+              width="150px" // 너비 150px로 설정
             >
-              이 제안 적용하기
-            </Button>
-          </SuggestionBox>
+              {isLoading ? "AI가 다듬는 중..." : (suggestion ? "AI 다른 제안 보기" : "AI 말투 다듬기")}
+            </SubmitButton>
+            <SubmitButton 
+              onClick={handleSubmit} 
+              disabled={isSubmitting || isLoading || message.trim().length === 0}
+              size="small"
+              width="150px" // 너비 150px로 설정
+            >
+              {isSubmitting ? "전송 중..." : "보내기"}
+            </SubmitButton>
+          </ButtonGroup>
+        </ContentWrapper>
+
+        {isLoadingCards && <p>카드 목록을 불러오는 중...</p>}
+        {!isLoadingCards && sentMessages.length > 0 && (
+          <SentCardsSection>
+            <SentCardsTitle>내가 보낸 감정 카드</SentCardsTitle>
+            <SentCardList>
+              {sentMessages.map(msg => (
+                <SentCardItem key={msg.id} onClick={() => openModal(msg)}>
+                  <p>{msg.text}</p>
+                  <span>{new Date(msg.createdAt).toLocaleTimeString()}</span>
+                </SentCardItem>
+              ))}
+            </SentCardList>
+          </SentCardsSection>
+        )}
+        {!isLoadingCards && !error && sentMessages.length === 0 && (
+            <SentCardsSection>
+                <SentCardsTitle>내가 보낸 감정 카드</SentCardsTitle>
+                <p>아직 보낸 감정 카드가 없어요.</p>
+            </SentCardsSection>
         )}
 
-        <ButtonGroup>
-          <Button onClick={handleSuggest} disabled={isLoading || message.trim().length === 0}>
-            {isLoading ? "제안 받는 중..." : (suggestion ? "다른 제안 보기" : "AI 말투 다듬기")}
-          </Button>
-          <Button onClick={handleSubmit} disabled={isLoading || message.trim().length === 0}>
-            보내기
-          </Button>
-        </ButtonGroup>
-      </Container>
-      <NavigationBar /> {/* EmotionCard에서도 NavigationBar 렌더링 */}
+      </PageContainer>
+
+      {isModalOpen && selectedMessage && (
+        <ModalBackground onClick={closeModal}> {/* 배경 클릭 시 닫기 */} 
+          <ModalContent onClick={(e) => e.stopPropagation()}> {/* 모달 내용 클릭은 전파 방지 */} 
+            <CloseButton onClick={closeModal}>&times;</CloseButton>
+            <h4>내가 보낸 감정 카드</h4>
+            <p>{selectedMessage.text}</p>
+            <span>보낸 시간: {new Date(selectedMessage.createdAt).toLocaleString()}</span>
+          </ModalContent>
+        </ModalBackground>
+      )}
+
+      <NavigationBar />
     </>
   );
 };

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -271,12 +271,15 @@ const LoginPage: React.FC = () => {
 
   const onSubmit = async (data: LoginFormData) => {
     try {
+      const requestUrl = `${axiosInstance.defaults.baseURL}/auth/login`;
+      console.log('[Login onSubmit] Requesting URL:', requestUrl);
+      console.log('[Login onSubmit] Request data:', data);
+
       const response = await axiosInstance.post('/auth/login', data);
       
       if (response.data.accessToken) {
         localStorage.setItem('accessToken', response.data.accessToken);
         
-        // 응답에서 직접 사용자 정보를 받아와서 저장
         if (response.data.user) {
           setUser(response.data.user);
           console.log('로그인 성공:', response.data.user);
@@ -285,7 +288,9 @@ const LoginPage: React.FC = () => {
         navigate('/dashboard');
       }
     } catch (error) {
+      console.error('[Login onSubmit] Full error object:', error);
       if (error instanceof AxiosError) {
+        console.error('[Login onSubmit] Axios error response:', error.response);
         setError(error.response?.data?.message || '로그인에 실패했습니다.');
       } else {
         setError('로그인 중 오류가 발생했습니다.');

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -5,11 +5,11 @@ export const logout = async (navigate: NavigateFunction) => {
     console.log('=== 로그아웃 시도 ===');
     console.log('📧 현재 로그인된 사용자:', localStorage.getItem('userNickname'));
     
-    const backendUrl = import.meta.env.VITE_APP_API_URL || 'http://localhost:3000';
+    const backendBaseUrl = import.meta.env.VITE_APP_API_URL || 'http://localhost:3000';
     const token = localStorage.getItem('accessToken');
     
-    // 백엔드에 로그아웃 요청
-    await fetch(`${backendUrl}/auth/logout`, {
+    // 백엔드에 로그아웃 요청 (경로에 '/api' 추가)
+    await fetch(`${backendBaseUrl}/api/auth/logout`, {
       method: 'POST',
       credentials: 'include',
       headers: {


### PR DESCRIPTION
- 감정 카드 작성 페이지 UI/UX 개선:
    - 카드 목록 표시: 작성한 감정 카드를 페이지 하단에 카드 형태로 표시하고, 클릭 시 모달로 상세 내용 확인 기능 추가
    - 버튼 스타일 및 레이아웃 개선: 'SubmitButton' 컴포넌트에 size, width prop 추가 및 'EmotionCard' 페이지 버튼 스타일 조정
    - 하단 여백 추가: 페이지 하단 콘텐츠가 네비게이션 바에 가려지지 않도록 여백 조정
- 감정 카드 백엔드 연동:
    - 작성한 감정 카드를 서버에 저장하고, 페이지 로드 시 서버에서 불러와 표시하도록 변경 (기존 로컬 상태 저장 방식 제거)
    - API 호출 시 로딩 상태(목록 조회, 카드 전송) 및 오류 처리 로직 개선
- AI 말투 다듬기 기능:
    - Gemeni API 연동 관련 프롬프트 수정 (백엔드 변경 사항에 대한 프론트엔드 반영은 없었으나, 기능의 연속성상 언급)